### PR TITLE
a11y: Accessible Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ To change the colors and graphics of the UI, edit the variables at the top of in
 The only files that you need to host your applet are index.html, index.css imagemaker.js, and the imagemakerAssets folder. To host on Github pages, fork this repo, customize the files, and follow the intrucutions [here](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site).
 
 Since this repo generates a static site, you can turn on Github Pages in the Settings of the Repo and it should automatically deploy for you, detecting the presence of an index.html file. It will host your builder at `yourRepoName.github.io`. You can change the name of your repository to get a URL you like.
+
+Pushing your changes to main will trigger a deploy.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 hackrew is a framework for making character creator/dressup game applets a la [picrew](https://picrew.me/). You can check out an online demo [here](https://ksadov.github.io/hackrew/), or see a more complex version on [Neocities](https://cherrvak.neocities.org/furrycreator/index.html). To make your own character creator, fork this repo or download the files and follow the instructions below.
 
+This builder uses hackrew as a base, and implements some accessibility improvements to allow more users to interact with it. 
+
 ## Instructions
 
 ### Step 1: start a web server

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ hackrew is a framework for making character creator/dressup game applets a la [p
 
 ### Step 1: start a web server
 
-The applet won't run correctly unless it's launched from a server. To launch it from your own machine, cd into the hackrew folder, run ./serve.sh (you'll need [Python 3 installed on your machine](https://www.python.org/downloads/)) from the command line and navigate to [http://localhost:8000/](http://localhost:8000/) in your browser. Once you're done developing your character creator, you can host it on a remote server, like Neocities or Github Pages.
+The applet won't run correctly unless it's launched from a server. To launch it from your own machine, cd into the hackrew folder, run `./serve.sh` (you'll need [Python 3 installed on your machine](https://www.python.org/downloads/)) from the command line and navigate to [http://localhost:8000/](http://localhost:8000/) in your browser. Once you're done developing your character creator, you can host it on a remote server, like Neocities or Github Pages.
 
 ### Step 2: specify your parts
 The character creator applet's visual components are comprised of "parts" (ex: "body", "ears", "tail", "accessories"), which have varieties called "items" (ex: the items for ears are "small" and "big"). Each item is represented by a .png image with a transparent background. The applet allows the user to create different characters by layering different item .pngs on top of each other. 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,8 @@ The script will take a while to run, but at the end you'll have your color varia
 ### Step 4: edit the UI
 To change the colors and graphics of the UI, edit the variables at the top of index.css.
 
-### Step 5: host your applet
+### Step 5: host your avatar builder
 
 The only files that you need to host your applet are index.html, index.css imagemaker.js, and the imagemakerAssets folder. To host on Github pages, fork this repo, customize the files, and follow the intrucutions [here](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site).
 
-To host on Neocities, make a new folder to contain your project (in my [example page](https://cherrvak.neocities.org/furrycreator/index.html), the folder is called "furrycreator"). Place the files index.html, index.css and imagemaker.js in this folder. Then place the folder imagemakerAssets in the same directory, but be careful to preserve the subfolder structure: the Neocities drag-and-drop GUI won't preserve the seperate folders for each part, which will break the code, so you're better off making a folder called imagemakerAssets and dragging-and-dropping in each part folder one-by-one. Then your completed applet will be on the page `https://your-neocities-page.neocities.org/your-folder-name/` (ex: https://cherrvak.neocities.org/furrycreator/)
-
-## TODO
-- Add item shift button or draggable items?
+Since this repo generates a static site, you can turn on Github Pages in the Settings of the Repo and it should automatically deploy for you, detecting the presence of an index.html file. It will host your builder at `yourRepoName.github.io`. You can change the name of your repository to get a URL you like.

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -104,12 +104,9 @@ window.addEventListener('load', function(ev) {
 		}
 	  });
 	itemsButton.addEventListener('click', toggleItems).addEventListener("keypress", function(event) {
-		// If the user presses the "Enter" key on the keyboard
 		if (event.key === "Enter") {
-		  // Cancel the default action, if needed
 		  event.preventDefault();
-		  // Trigger the button element with a click
-		  document.getElementById("myBtn").click();
+		  document.getElementById(itemsButton).click();
 		}
 	  });
 	return null;

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -253,8 +253,10 @@ window.addEventListener('load', function(ev) {
 		let noneButtonIcon = document.createElement('img');
 		noneButtonIcon.src = assetsPath + "none_button.svg";
 		noneButton.appendChild(noneButtonIcon);
+		noneButtonIcon.alt = "none";
 		document.getElementById("itemlist_list").appendChild(noneButton);
 		noneButton.style.display = "none";
+		
 		itemsElements[i][0] = noneButton;
  	    }
 	    for (let j = 0; j < parts[i].items.length; j++) {

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -266,6 +266,7 @@ window.addEventListener('load', function(ev) {
 		itemIcon.src = (assetsPath +
 				parts[i].folder + "/" +
 				parts[i].items[j] + ".png");
+		itemIcon.alt = parts[i].items[j].toString();
 		item.appendChild(itemIcon);
 		item.id = "item_" + i.toString() + "_" + j.toString();
 		item.style.display = "none";

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -257,7 +257,7 @@ window.addEventListener('load', function(ev) {
 		itemsElements[i][0] = noneButton;
  	    }
 	    for (let j = 0; j < parts[i].items.length; j++) {
-		let item = document.createElement('li');
+		let item = document.createElement('button');
 		let itemIcon = document.createElement('img');
 		itemIcon.id = "icon_" + i.toString() + "_" + j.toString();
 		itemIcon.src = (assetsPath +

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -85,12 +85,45 @@ window.addEventListener('load', function(ev) {
      * Assign functions to buttons.
      */
     function initButtons() {
-	randomButton.addEventListener('click', randomize);
-	infoButton.addEventListener('click', toggleInfo);
-	paletteButton.addEventListener('click', togglePalette);
-	itemsButton.addEventListener('click', toggleItems);
+	randomButton.addEventListener('click', randomize).addEventListener("keypress", function(event) {
+		if (event.key === "Enter") {
+		  event.preventDefault();
+		  document.getElementById(randomButton).click();
+		}
+	  });
+	infoButton.addEventListener('click', toggleInfo).addEventListener("keypress", function(event) {
+		if (event.key === "Enter") {
+		  event.preventDefault();
+		  document.getElementById(infoButton).click();
+		}
+	  });
+	paletteButton.addEventListener('click', togglePalette).addEventListener("keypress", function(event) {
+		if (event.key === "Enter") {
+		  event.preventDefault();
+		  document.getElementById(paletteButton).click();
+		}
+	  });
+	itemsButton.addEventListener('click', toggleItems).addEventListener("keypress", function(event) {
+		// If the user presses the "Enter" key on the keyboard
+		if (event.key === "Enter") {
+		  // Cancel the default action, if needed
+		  event.preventDefault();
+		  // Trigger the button element with a click
+		  document.getElementById("myBtn").click();
+		}
+	  });
 	return null;
     }
+
+	.addEventListener("keypress", function(event) {
+  // If the user presses the "Enter" key on the keyboard
+  if (event.key === "Enter") {
+    // Cancel the default action, if needed
+    event.preventDefault();
+    // Trigger the button element with a click
+    document.getElementById("myBtn").click();
+  }
+});
 
     /**
      * Initialize partsElements, itemsElements

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -113,6 +113,7 @@ window.addEventListener('load', function(ev) {
 		});
 		colorElement.id = "color_" + i.toString() + "_" + j.toString();
 		colorElement.style.display = "none";
+		colorElement.ariaLabel = parts[i].folder.toString() + " " + ntc.name(parts[i].colors[j])[1];
 		document.getElementById("colorpalette_list").appendChild(colorElement);
 	    }
 	}
@@ -266,7 +267,7 @@ window.addEventListener('load', function(ev) {
 		itemIcon.src = (assetsPath +
 				parts[i].folder + "/" +
 				parts[i].items[j] + ".png");
-		itemIcon.alt = parts[i].items[j].toString();
+		itemIcon.alt = parts[i].folder + " " +parts[i].items[j].toString();
 		item.appendChild(itemIcon);
 		item.id = "item_" + i.toString() + "_" + j.toString();
 		item.style.display = "none";

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -112,15 +112,6 @@ window.addEventListener('load', function(ev) {
 	return null;
     }
 
-	.addEventListener("keypress", function(event) {
-  // If the user presses the "Enter" key on the keyboard
-  if (event.key === "Enter") {
-    // Cancel the default action, if needed
-    event.preventDefault();
-    // Trigger the button element with a click
-    document.getElementById("myBtn").click();
-  }
-});
 
     /**
      * Initialize partsElements, itemsElements

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -231,6 +231,7 @@ window.addEventListener('load', function(ev) {
 	    part.appendChild(partIcon);
 	    part.id = "part_" + i.toString();
             document.getElementById('parts_list').appendChild(part);
+		partIcon.alt = parts[i].folder.toString()
 	    partsElements[i] = part;
 	}
 	return null;

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -106,7 +106,7 @@ window.addEventListener('load', function(ev) {
      function initPalette() {
 	for (let i = 0; i < parts.length; i++) {
 	    for (let j = 0; j < parts[i].colors.length; j++) {
-		let colorElement = document.createElement('li');
+		let colorElement = document.createElement('button');
 		colorElement.style.backgroundColor = "#" + parts[i].colors[j];
 		colorElement.addEventListener('click', function() {
 		    selectColor(i, j);
@@ -248,7 +248,7 @@ window.addEventListener('load', function(ev) {
 	}
 	for (let i = 0; i < parts.length; i++) {
 	    if (parts[i].noneAllowed) {
-		let noneButton = document.createElement('li');
+		let noneButton = document.createElement('button');
 		let noneButtonIcon = document.createElement('img');
 		noneButtonIcon.src = assetsPath + "none_button.svg";
 		noneButton.appendChild(noneButtonIcon);

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -225,7 +225,7 @@ window.addEventListener('load', function(ev) {
      */
     function initPartsElements() {
 	for (let i = 0; i < parts.length; i++) {	
-	    let part = document.createElement('li');
+	    let part = document.createElement('button');
 	    let partIcon = document.createElement('img');
 	    partIcon.src = assetsPath + parts[i].folder + "/icon.png";
 	    part.appendChild(partIcon);

--- a/imagemaker.js
+++ b/imagemaker.js
@@ -85,33 +85,11 @@ window.addEventListener('load', function(ev) {
      * Assign functions to buttons.
      */
     function initButtons() {
-	randomButton.addEventListener('click', randomize).addEventListener("keypress", function(event) {
-		if (event.key === "Enter") {
-		  event.preventDefault();
-		  document.getElementById(randomButton).click();
-		}
-	  });
-	infoButton.addEventListener('click', toggleInfo).addEventListener("keypress", function(event) {
-		if (event.key === "Enter") {
-		  event.preventDefault();
-		  document.getElementById(infoButton).click();
-		}
-	  });
-	paletteButton.addEventListener('click', togglePalette).addEventListener("keypress", function(event) {
-		if (event.key === "Enter") {
-		  event.preventDefault();
-		  document.getElementById(paletteButton).click();
-		}
-	  });
-	itemsButton.addEventListener('click', toggleItems).addEventListener("keypress", function(event) {
-		if (event.key === "Enter") {
-		  event.preventDefault();
-		  document.getElementById(itemsButton).click();
-		}
-	  });
+	randomButton.addEventListener('click', randomize);
+	paletteButton.addEventListener('click', togglePalette);
+	itemsButton.addEventListener('click', toggleItems);
 	return null;
     }
-
 
     /**
      * Initialize partsElements, itemsElements

--- a/index.css
+++ b/index.css
@@ -6,7 +6,7 @@
     /* the color of the focus ring */
     --focus-color: #0008ff;
     /* the color/image filepath of the background of the image display area */
-    --image-background-color: hsla(0,0%,93.3%,.5);
+    --image-background-color: hsla(0, 0%, 93.3%, .5);
     --image-background-png: "none";
     /* the color/image filepath of the random button */
     --random-button-color: #9d05f0;
@@ -34,7 +34,8 @@
     box-sizing: border-box;
 }
 
-button:focus-visible, a:focus-visible {
+button:focus-visible,
+a:focus-visible {
     outline: 3px solid var(--focus-color);
 }
 
@@ -43,98 +44,94 @@ body {
 }
 
 .sr-only {
-	border: 0 !important;
-	clip: rect(1px, 1px, 1px, 1px) !important; /* 1 */
-	-webkit-clip-path: inset(50%) !important;
-		clip-path: inset(50%) !important;  /* 2 */
-	height: 1px !important;
-	margin: -1px !important;
-	overflow: hidden !important;
-	padding: 0 !important;
-	position: absolute !important;
-	width: 1px !important;
-	white-space: nowrap !important;            /* 3 */
+    border: 0 !important;
+    clip: rect(1px, 1px, 1px, 1px) !important;
+    /* 1 */
+    -webkit-clip-path: inset(50%) !important;
+    clip-path: inset(50%) !important;
+    /* 2 */
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+    white-space: nowrap !important;
+    /* 3 */
 }
 
 
 @media (orientation: landscape) {
     .imagemaker_container_wrapper {
-	width: 800px;
+        width: 800px;
     }
-    
+
     .imagemaker_container {
-	flex-direction: row;
+        flex-direction: row;
     }
-    
+
     .imagemaker_canvas_wrapper {
-	max-height: 100%;
+        max-height: 100%;
     }
 
     .imagemaker_save_button {
-	top: 5px;
-	height: 36px;
+        top: 5px;
+        height: 36px;
     }
 
     .imagemaker_ctrl_buttons {
-	position: absolute;
-	top: 4px;
-	right: 4px;
-	bottom: auto;
-	left: auto;
-	width: 50px;
-	height: 50px;
-	z-index: 0;
+        position: absolute;
+        top: 10px;
+        right: 65px;
+        bottom: auto;
+        left: auto;
+        width: 50px;
+        height: 50px;
+        z-index: 0;
     }
 
     .imagemaker_control_wrapper {
-	position: relative;
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	min-width: 275px;
-	height: 100%
+        position: relative;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-width: 275px;
+        height: 100%
     }
 
 
     .imagemaker_random_button {
-	min-width: 60px;
-	font-size: 14px;
+        min-width: 60px;
+        font-size: 14px;
     }
 
     .imagemaker_parts_menu ul {
-	margin-left: 10px;
+        margin-left: 10px;
     }
 
     .imagemaker_itemlist ul li {
-	width: 33.2%;
+        width: 33.2%;
     }
 
     .imagemaker_parts_menu {
-	height: 68px;
+        height: 68px;
     }
 
     .imagemaker_parts_menu ul li {
-	width: 60px;
-	height: auto;
+        width: 60px;
+        height: auto;
     }
 
-    .imagemaker_ctrl_buttons .button_show_itemlist {
-	width: 50px;
-	height: 50px;
-	line-height: 50px;
+    .imagemaker_ctrl_buttons button {
+        min-width: 50px;
+        height: 50px;
+        line-height: 50px;
     }
 
-    .imagemaker_ctrl_buttons .button_show_colorpalette {
-	align-items: center;
-	width: 50px;
-	height: 50px;
-	line-height: 50px;
-	left: -55px;
-    }
 
     .imagemaker_colorpalette ul li {
-	width: 48px;
-	height: 48px;
+        width: 48px;
+        height: 48px;
     }
 
 
@@ -142,107 +139,103 @@ body {
 
 @media (orientation: portrait) {
     .loading {
-    font-size: 3vh;
+        font-size: 3vh;
     }
-    
+
     .imagemaker_container_wrapper {
-	width: 95vw;
-	min-height: 95vh;
+        width: 95vw;
+        min-height: 95vh;
     }
 
     .imagemaker_container {
-	flex-direction: column;
+        flex-direction: column;
     }
 
     .imagemaker_canvas_wrapper {
-	max-height: 50vh;
+        max-height: 50vh;
     }
 
     .imagemaker_save_button {
-	height: 4vh;
-	font-size: 3vh;
+        height: 4vh;
+        font-size: 3vh;
     }
 
     .imagemaker_ctrl_buttons {
-	bottom: 4px;
-	right: 4px;
-	top: auto;
-	left: auto;
+        position:absolute;
+        bottom: 10px;
+        right: 10px;
+        top: auto;
+        left: auto;
     }
 
     .imagemaker_control_wrapper {
-	position: relative;
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	height: 100%
+        position: relative;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        height: 100%
     }
 
     .imagemaker_parts_menu_wrapper {
-	padding-left: 18.18%;
+        padding-left: 18.18%;
     }
 
     .imagemaker_parts_menu ul {
-	margin-left: 0px;
+        margin-left: 0px;
     }
 
     .imagemaker_itemlist ul li {
-	width: 23.75%;
+        width: 23.75%;
     }
 
     .imagemaker_parts_menu_wrapper {
-	min-height: 10vh;
-    }
-    
-    .imagemaker_parts_menu {
-	height: 100%;
+        min-height: 10vh;
     }
 
-     .imagemaker_parts_menu ul {
-	width: auto;
-	height: 100%;
-     }
-     
+    .imagemaker_parts_menu {
+        height: 100%;
+    }
+
+    .imagemaker_parts_menu ul {
+        width: auto;
+        height: 100%;
+    }
+
     .imagemaker_parts_menu ul li {
-	width: 9vh;
-	height: 9vh;
+        width: 9vh;
+        height: 9vh;
     }
 
     .imagemaker_parts_menu ul li img {
-	width: 100%;
-	height: 100%;
-	position: relative;
+        width: 100%;
+        height: 100%;
+        position: relative;
     }
 
     .imagemaker_random_button {
-	font-size: 4vw;
-    }
-
-    .imagemaker_ctrl_buttons {
-	width: 6vh;
-	height: 6vh;
+        font-size: 4vw;
     }
 
     .imagemaker_ctrl_buttons .button_show_colorpalette {
-	width: 6vh;
-	height: 6vh;
-	line-height: 6vh;
-	left: -10vh;
-	bottom: 4px;
+        width: 6vh;
+        height: 6vh;
+        line-height: 6vh;
+        left: -10vh;
+        bottom: 4px;
     }
 
     .imagemaker_ctrl_buttons .button_show_itemlist {
-	width: 6vh;
-	height: 6vh;
-	bottom: 4px;
-	right: 4px;
+        width: 6vh;
+        height: 6vh;
+        bottom: 4px;
+        right: 4px;
     }
 
     .imagemaker_colorpalette ul li {
-	width: 8vh;
-	height: 8vh;
+        width: 8vh;
+        height: 8vh;
     }
-    
+
 }
 
 .imagemaker_container_wrapper {
@@ -257,7 +250,7 @@ body {
     height: 100%;
     display: flex;
     overflow: hidden;
-    background-color: var(--image-background-color, hsla(0,0%,93.3%,.5));
+    background-color: var(--image-background-color, hsla(0, 0%, 93.3%, .5));
     background-image: var(--image-background-png, none);
     background-position: center;
     background-repeat: no-repeat;
@@ -310,6 +303,7 @@ body {
 
 .imagemaker_ctrl_buttons {
     z-index: 0;
+    display: flex;
 }
 
 .imagemaker_control_wrapper {
@@ -435,7 +429,6 @@ body {
     border-radius: 50%;
     cursor: pointer;
     text-align: center;
-    position: absolute;
 }
 
 .imagemaker_ctrl_buttons .button_show_controller {
@@ -473,7 +466,6 @@ body {
     border-radius: 50%;
     cursor: pointer;
     text-align: center;
-    position: absolute;
 }
 
 .imagemaker_logo {
@@ -485,7 +477,7 @@ body {
     display: inline-block;
     background-size: contain;
     background-repeat: no-repeat;
-    background-color:  #ff597e;
+    background-color: #ff597e;
     background-image: var(--logo-png, "none");
     width: 66px;
     height: 20px;
@@ -521,11 +513,11 @@ body {
     border-radius: 50%;
     border: 2px solid #eee;
     box-sizing: border-box;
-    list-style-type: none!important;
+    list-style-type: none !important;
     cursor: pointer;
 }
 
-.imagemaker_colorpalette ul > * {
+.imagemaker_colorpalette ul>* {
     display: inline-block;
     list-style-type: none;
     margin: 0;
@@ -533,4 +525,3 @@ body {
     vertical-align: middle;
     font-size: 1rem;
 }
-

--- a/index.css
+++ b/index.css
@@ -109,7 +109,7 @@ body {
         margin-left: 10px;
     }
 
-    .imagemaker_itemlist ul li {
+    .imagemaker_itemlist ul button {
         width: 33.2%;
     }
 

--- a/index.css
+++ b/index.css
@@ -105,11 +105,11 @@ body {
         font-size: 14px;
     }
 
-    .imagemaker_parts_menu ul {
+    .imagemaker_parts_menu div {
         margin-left: 10px;
     }
 
-    .imagemaker_itemlist ul button {
+    .imagemaker_itemlist div button {
         width: 33.2%;
     }
 

--- a/index.css
+++ b/index.css
@@ -34,8 +34,8 @@
     box-sizing: border-box;
 }
 
-*:focus {
-    outline: 3px solid --focus-color;
+button:focus-visible, a:focus-visible {
+    outline: 3px solid var(--focus-color);
 }
 
 body {

--- a/index.css
+++ b/index.css
@@ -500,7 +500,7 @@ body {
     -webkit-overflow-scrolling: touch;
 }
 
-.imagemaker_colorpalette ul {
+.imagemaker_colorpalette div {
     padding: 0;
     font-size: 0;
     width: 100%;

--- a/index.css
+++ b/index.css
@@ -3,6 +3,8 @@
     --loading-bg-color: #FFFFFF;
     /* the color of the border around selected part and icon buttons */
     --select-color: #FF0000;
+    /* the color of the focus ring */
+    --focus-color: #0008ff;
     /* the color/image filepath of the background of the image display area */
     --image-background-color: hsla(0,0%,93.3%,.5);
     --image-background-png: "none";
@@ -30,6 +32,10 @@
     min-width: 0;
     word-wrap: break-word;
     box-sizing: border-box;
+}
+
+*:focus {
+    outline: 3px solid --focus-color;
 }
 
 body {

--- a/index.css
+++ b/index.css
@@ -7,7 +7,7 @@
     --image-background-color: hsla(0,0%,93.3%,.5);
     --image-background-png: "none";
     /* the color/image filepath of the random button */
-    --random-button-color: #ffbd15;
+    --random-button-color: #9d05f0;
     --random-button-png: "none";
     /* the color/image filepath of the items menu background*/
     --control-panel-color: #ccc;
@@ -20,15 +20,9 @@
     /* the color/image filepath of the palette toggle button */
     --palette-toggle-color: #fff;
     --palette-toggle-svg: url("imagemakerAssets/palette_toggle.svg");
-    /* the color/image filepath of the info button */
-    --info-toggle-color: #fff;
-    --info-toggle-png: "none";
-    /* the color/image filepath of the info button */
-    --move-toggle-color: #fff;
-    --move-toggle-svg: url("imagemakerAssets/move_toggle.svg");
     /* the image filepath of the logo */
     --logo-png: "none";
-    --save-button-color: #00b33c;
+    --save-button-color: #008a2e;
 }
 
 * {
@@ -56,9 +50,6 @@ body {
 	white-space: nowrap !important;            /* 3 */
 }
 
-.imagemaker {
-    height: 100%;
-}
 
 @media (orientation: landscape) {
     .imagemaker_container_wrapper {
@@ -98,15 +89,6 @@ body {
 	height: 100%
     }
 
-    .imagemaker_info_show_button {
-	position: absolute;
-	top: auto;
-	right: auto;
-	bottom: 4px;
-	left: 4px;
-	width: 50px;
-	height: 50px;
-    }
 
     .imagemaker_random_button {
 	min-width: 60px;
@@ -149,9 +131,7 @@ body {
 	height: 48px;
     }
 
-    .imagemaker_info_content {
-	font-size: 3vh;
-    }
+
 }
 
 @media (orientation: portrait) {
@@ -190,17 +170,6 @@ body {
 	display: flex;
 	flex-direction: column;
 	height: 100%
-    }
-
-    .imagemaker_info_show_button {
-	position: absolute;
-	top: 4px;
-	right: 4px;
-	bottom: auto;
-	left: auto;
-	height: 6vh;
-	width: 6vh;
-	font-size: 5vh
     }
 
     .imagemaker_parts_menu_wrapper {
@@ -501,22 +470,6 @@ body {
     position: absolute;
 }
 
-.imagemaker_info_show_button {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    background-color: var(--info-toggle-color, #fff);
-    background-image: var(--info-toggle-png, "none");
-    background-position: center;
-    background-repeat: no-repeat;
-    color: #333;
-    border: 0 solid #aaa;
-    border-radius: 50%;
-    cursor: pointer;
-    text-align: center;
-    z-index: 20;
-}
-
 .imagemaker_logo {
     position: absolute;
     top: 6px;
@@ -536,24 +489,6 @@ body {
 
 .selected {
     border: 3px solid var(--select-color, #ff0000);
-}
-
-.imagemaker_info_wrapper {
-    height: 100%;
-    background-color: #eeeeee;
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    bottom: 4px;
-    left: 4px;
-    height: calc(100% - 8px);
-    overflow: hidden;
-    z-index: 10;
-    display: none;
-}
-
-.imagemaker_info_content {
-    margin: 10px;
 }
 
 .imagemaker_colorpalette {

--- a/index.css
+++ b/index.css
@@ -321,8 +321,6 @@ body {
     position: absolute;
     font-size: 3vh;
     background-color: var(--loading-bg-color, #FFFFFF);
-    //padding: 3px;
-    //bottom: 4px;
 }
 
 .imagemaker_canvas_wrapper canvas {
@@ -336,9 +334,6 @@ body {
 
 
 .imagemaker_ctrl_buttons {
-    position: absolute;
-    width: 50px;
-    height: 50px;
     z-index: 0;
 }
 

--- a/index.css
+++ b/index.css
@@ -42,6 +42,20 @@ body {
     height: 90vh;
 }
 
+.sr-only {
+	border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important; /* 1 */
+	-webkit-clip-path: inset(50%) !important;
+		clip-path: inset(50%) !important;  /* 2 */
+	height: 1px !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	white-space: nowrap !important;            /* 3 */
+}
+
 .imagemaker {
     height: 100%;
 }

--- a/index.css
+++ b/index.css
@@ -105,7 +105,7 @@ body {
         font-size: 14px;
     }
 
-    .imagemaker_parts_menu div {
+    .imagemaker_parts_menu nav {
         margin-left: 10px;
     }
 
@@ -117,7 +117,7 @@ body {
         height: 68px;
     }
 
-    .imagemaker_parts_menu ul li {
+    .imagemaker_parts_menu nav button {
         width: 60px;
         height: auto;
     }
@@ -129,7 +129,7 @@ body {
     }
 
 
-    .imagemaker_colorpalette ul li {
+    .imagemaker_colorpalette div button{
         width: 48px;
         height: 48px;
     }
@@ -180,11 +180,11 @@ body {
         padding-left: 18.18%;
     }
 
-    .imagemaker_parts_menu ul {
+    .imagemaker_parts_menu nav {
         margin-left: 0px;
     }
 
-    .imagemaker_itemlist ul li {
+    .imagemaker_itemlist div button {
         width: 23.75%;
     }
 
@@ -196,17 +196,17 @@ body {
         height: 100%;
     }
 
-    .imagemaker_parts_menu ul {
+    .imagemaker_parts_menu nav {
         width: auto;
         height: 100%;
     }
 
-    .imagemaker_parts_menu ul li {
+    .imagemaker_parts_menu nav button {
         width: 9vh;
         height: 9vh;
     }
 
-    .imagemaker_parts_menu ul li img {
+    .imagemaker_parts_menu nav button img {
         width: 100%;
         height: 100%;
         position: relative;
@@ -231,7 +231,7 @@ body {
         right: 4px;
     }
 
-    .imagemaker_colorpalette ul li {
+    .imagemaker_colorpalette div button {
         width: 8vh;
         height: 8vh;
     }
@@ -329,7 +329,7 @@ body {
     -ms-overflow-style: scrollbar;
 }
 
-.imagemaker_parts_menu ul {
+.imagemaker_parts_menu nav {
     margin-right: 0;
     margin-top: 0;
     margin-bottom: 0;
@@ -338,7 +338,7 @@ body {
     list-style: "none";
 }
 
-.imagemaker_parts_menu ul li {
+.imagemaker_parts_menu nav button{
     position: relative;
     min-width: 48px;
     margin: 4px 2px 4px 2px;
@@ -399,7 +399,7 @@ body {
     margin: .5%;
 }
 
-.imagemaker_itemlist ul li {
+.imagemaker_itemlist div button {
     margin: 5px;
     background-color: var(--item-button-color, #fff);
     border-radius: 4px;
@@ -412,7 +412,7 @@ body {
     cursor: pointer;
 }
 
-.imagemaker_itemlist ul li img {
+.imagemaker_itemlist div button img {
     width: 100%;
     height: 100%;
 }
@@ -508,7 +508,7 @@ body {
     text-align: center;
 }
 
-.imagemaker_colorpalette ul li {
+.imagemaker_colorpalette div button {
     margin: 1px;
     border-radius: 50%;
     border: 2px solid #eee;

--- a/index.html
+++ b/index.html
@@ -8,15 +8,14 @@
 </head>
 
 <body>
+	<script src="imagemaker.js"></script>
 	<header>
 		<h1>Character Builder</h1>
 	</header>
-	<main></main>
-	<script src="imagemaker.js"></script>
-	<div id="image-maker" class="imagemaker">
+	<main id="image-maker" class="imagemaker">
 		<div class="imagemaker_container_wrapper">
 			<div class="imagemaker_container">
-				<div class="imagemaker_canvas_wrapper">
+				<section class="imagemaker_canvas_wrapper">
 					<canvas id="my-canvas-object" width="600" height="600" aria-label="character preview"></canvas>
 					<a class="imagemaker_save_button" id="save" download="new_image.png">
 						Save
@@ -30,8 +29,8 @@
 						<button id="palette_button" class="button_show_colorpalette" tabindex="0"><span
 								class="sr-only">Colors</span></button>
 					</div>
-				</div>
-				<div class="imagemaker_control_wrapper">
+				</section>
+				<aside class="imagemaker_control_wrapper">
 					<div class="imagemaker_parts_menu_wrapper">
 						<div class="imagemaker_parts_menu">
 							<ul id="parts_list">
@@ -53,7 +52,7 @@
 							</div>
 						</div>
 					</div>
-				</div>
+				</aside>
 			</div>
 
 			<a class="imagemaker_logo" href="/" exact=""></a>

--- a/index.html
+++ b/index.html
@@ -26,9 +26,8 @@
 	      Loading...
 	    </a>
 	    <div class="imagemaker_ctrl_buttons">
-	      <span id="move_button" class="button_show_controller"></span>
-	      <span id="items_button" class="button_show_itemlist"></span>
-	      <span id="palette_button" class="button_show_colorpalette"></span>
+	      <button id="items_button" class="button_show_itemlist">Items</button>
+	      <button id="palette_button" class="button_show_colorpalette">Colors</button>
 	    </div>	    
 	  </div>
 	  <div class="imagemaker_control_wrapper">

--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
 				<aside class="imagemaker_control_wrapper">
 					<div class="imagemaker_parts_menu_wrapper">
 						<div class="imagemaker_parts_menu">
-							<ul id="parts_list">
-							</ul>
+							<nav id="parts_list">
+							</nav>
 						</div>
 						<button class="imagemaker_random_button" id="random_button" tabindex="0">
 							Random

--- a/index.html
+++ b/index.html
@@ -1,63 +1,76 @@
 <!DOCTYPE html>
 <html lang=en>
-  <head>
-    <meta charset="UTF-8"/>
-    <link rel="stylesheet" href="index.css">
+
+<head>
+	<meta charset="UTF-8" />
+	<link rel="stylesheet" href="index.css">
 	<title>Character Builder</title>
-  </head>
-  <body>
-    <script src="imagemaker.js"></script> 
-    <div id="image-maker" class="imagemaker">
-      <div class="imagemaker_container_wrapper">
-	<div id="info_wrap" class="imagemaker_info_wrapper">
-	  <div class="imagemaker_info_content">
-	    <p>
-	      This builder is based on the open-source character creator
-	      framework, <a target="_blank" href="https://github.com/ksadov/hackrew">hackrew<span class="sr-only">(opens in a new window)</span></a>.
-	    </p>
-	  </div>
-	</div>
-	<div class="imagemaker_container">
-	  <div class="imagemaker_canvas_wrapper">
-	    <canvas id="my-canvas-object" width="600" height="600" aria-label="character preview"></canvas>
-	    <a class="imagemaker_save_button" id="save" download="new_image.png">
-	      Save
-	    </a>
-	    <a class="loading" id="loading">
-	      Loading...
-	    </a>
-	    <div class="imagemaker_ctrl_buttons">
-	      <button id="items_button" class="button_show_itemlist"><span class="sr-only">Items</span></button>
-	      <button id="palette_button" class="button_show_colorpalette"><span class="sr-only">Colors</span></button>
-	    </div>	    
-	  </div>
-	  <div class="imagemaker_control_wrapper">
-	    <div class="imagemaker_parts_menu_wrapper">
-	      <div class="imagemaker_parts_menu">
-		<ul id="parts_list">
-		</ul>
-	      </div>
-	      <div class="imagemaker_random_button" id="random_button">
-		Random
-	      </div>
-	    </div>
-	    <div class="imagemaker_control_panel_wrapper">
-	      <div class="imagemaker_control_panel">
-		<div id="imagemaker_itemlist" class="imagemaker_itemlist">
-		  <ul id="itemlist_list">
-		  </ul>
+</head>
+
+<body>
+	<header>
+		<h1>Character Builder</h1>
+	</header>
+	<main></main>
+	<script src="imagemaker.js"></script>
+	<div id="image-maker" class="imagemaker">
+		<div class="imagemaker_container_wrapper">
+			<div id="info_wrap" class="imagemaker_info_wrapper">
+				<div class="imagemaker_info_content">
+					<p>
+						This builder is based on the open-source character creator
+						framework, <a target="_blank" href="https://github.com/ksadov/hackrew">hackrew<span
+								class="sr-only">(opens in a new window)</span></a>.
+					</p>
+				</div>
+			</div>
+			<div class="imagemaker_container">
+				<div class="imagemaker_canvas_wrapper">
+					<canvas id="my-canvas-object" width="600" height="600" aria-label="character preview"></canvas>
+					<a class="imagemaker_save_button" id="save" download="new_image.png">
+						Save
+					</a>
+					<a class="loading" id="loading">
+						Loading...
+					</a>
+					<div class="imagemaker_ctrl_buttons">
+						<button id="items_button" class="button_show_itemlist"><span
+								class="sr-only">Items</span></button>
+						<button id="palette_button" class="button_show_colorpalette"><span
+								class="sr-only">Colors</span></button>
+					</div>
+				</div>
+				<div class="imagemaker_control_wrapper">
+					<div class="imagemaker_parts_menu_wrapper">
+						<div class="imagemaker_parts_menu">
+							<ul id="parts_list">
+							</ul>
+						</div>
+						<button class="imagemaker_random_button" id="random_button">
+							Random
+						</button>
+					</div>
+					<div class="imagemaker_control_panel_wrapper">
+						<div class="imagemaker_control_panel">
+							<div id="imagemaker_itemlist" class="imagemaker_itemlist">
+								<ul id="itemlist_list">
+								</ul>
+							</div>
+							<div id="imagemaker_colorpalette" class="imagemaker_colorpalette">
+								<ul id="colorpalette_list">
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<a class="imagemaker_logo" href="/" exact=""></a>
 		</div>
-		<div id="imagemaker_colorpalette" class="imagemaker_colorpalette">
-		  <ul id="colorpalette_list">
-		  </ul>
-		</div>
-	      </div>
-	    </div>
-	  </div>
-	  <span id="info_button" class="imagemaker_info_show_button">?</span>
 	</div>
-	<a class = "imagemaker_logo" href="/" exact=""></a>
-      </div>
-    </div>
-  </body>
+	</main>
+	<footer>
+	</footer>
+</body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
 					<div class="imagemaker_control_panel_wrapper">
 						<div class="imagemaker_control_panel">
 							<div id="imagemaker_itemlist" class="imagemaker_itemlist">
-								<ul id="itemlist_list">
-								</ul>
+								<div id="itemlist_list">
+								</div>
 							</div>
 							<div id="imagemaker_colorpalette" class="imagemaker_colorpalette">
 								<ul id="colorpalette_list">

--- a/index.html
+++ b/index.html
@@ -24,21 +24,22 @@
 						Loading...
 					</a>
 					<div class="imagemaker_ctrl_buttons">
-						<button id="items_button" class="button_show_itemlist" tabindex="0"><span
+						<button id="items_button" class="button_show_itemlist"><span
 								class="sr-only">Items</span></button>
-						<button id="palette_button" class="button_show_colorpalette" tabindex="0"><span
+						<button id="palette_button" class="button_show_colorpalette"><span
 								class="sr-only">Colors</span></button>
+						
 					</div>
 				</section>
 				<aside class="imagemaker_control_wrapper">
 					<div class="imagemaker_parts_menu_wrapper">
 						<div class="imagemaker_parts_menu">
+							<button class="imagemaker_random_button" id="random_button">
+								Random
+							</button>
 							<nav id="parts_list">
 							</nav>
 						</div>
-						<button class="imagemaker_random_button" id="random_button" tabindex="0">
-							Random
-						</button>
 					</div>
 					<div class="imagemaker_control_panel_wrapper">
 						<div class="imagemaker_control_panel">

--- a/index.html
+++ b/index.html
@@ -15,15 +15,6 @@
 	<script src="imagemaker.js"></script>
 	<div id="image-maker" class="imagemaker">
 		<div class="imagemaker_container_wrapper">
-			<div id="info_wrap" class="imagemaker_info_wrapper">
-				<div class="imagemaker_info_content">
-					<p>
-						This builder is based on the open-source character creator
-						framework, <a target="_blank" href="https://github.com/ksadov/hackrew">hackrew<span
-								class="sr-only">(opens in a new window)</span></a>.
-					</p>
-				</div>
-			</div>
 			<div class="imagemaker_container">
 				<div class="imagemaker_canvas_wrapper">
 					<canvas id="my-canvas-object" width="600" height="600" aria-label="character preview"></canvas>
@@ -34,9 +25,9 @@
 						Loading...
 					</a>
 					<div class="imagemaker_ctrl_buttons">
-						<button id="items_button" class="button_show_itemlist"><span
+						<button id="items_button" class="button_show_itemlist" tabindex="0"><span
 								class="sr-only">Items</span></button>
-						<button id="palette_button" class="button_show_colorpalette"><span
+						<button id="palette_button" class="button_show_colorpalette" tabindex="0"><span
 								class="sr-only">Colors</span></button>
 					</div>
 				</div>
@@ -46,7 +37,7 @@
 							<ul id="parts_list">
 							</ul>
 						</div>
-						<button class="imagemaker_random_button" id="random_button">
+						<button class="imagemaker_random_button" id="random_button" tabindex="0">
 							Random
 						</button>
 					</div>
@@ -70,6 +61,15 @@
 	</div>
 	</main>
 	<footer>
+		<div id="info_wrap" class="imagemaker_info_wrapper">
+			<div class="imagemaker_info_content">
+				<p>
+					This builder is based on the open-source character creator
+					framework, <a target="_blank" href="https://github.com/ksadov/hackrew">hackrew<span
+							class="sr-only">(opens in a new window)</span></a>.
+				</p>
+			</div>
+		</div>
 	</footer>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8"/>
     <link rel="stylesheet" href="index.css">
+	<title>Character Builder</title>
   </head>
   <body>
     <script src="imagemaker.js"></script> 
@@ -18,7 +19,7 @@
 	</div>
 	<div class="imagemaker_container">
 	  <div class="imagemaker_canvas_wrapper">
-	    <canvas id="my-canvas-object" width="600" height="600"></canvas>
+	    <canvas id="my-canvas-object" width="600" height="600" aria-label="character preview"></canvas>
 	    <a class="imagemaker_save_button" id="save" download="new_image.png">
 	      Save
 	    </a>
@@ -26,8 +27,8 @@
 	      Loading...
 	    </a>
 	    <div class="imagemaker_ctrl_buttons">
-	      <button id="items_button" class="button_show_itemlist">Items</button>
-	      <button id="palette_button" class="button_show_colorpalette">Colors</button>
+	      <button id="items_button" class="button_show_itemlist"><span class="sr-only">Items</span></button>
+	      <button id="palette_button" class="button_show_colorpalette"><span class="sr-only">Colors</span></button>
 	    </div>	    
 	  </div>
 	  <div class="imagemaker_control_wrapper">

--- a/index.html
+++ b/index.html
@@ -11,12 +11,8 @@
 	<div id="info_wrap" class="imagemaker_info_wrapper">
 	  <div class="imagemaker_info_content">
 	    <p>
-	      I made this applet using my open-source character creator
+	      I made this applet using the open-source character creator
 	      framework, <a href="https://github.com/ksadov/hackrew">hackrew</a>.
-	    </p>
-	    <p>
-	      If you're interested in making your own, I suggest
-	      checking out the linked Github repository for documentation.
 	    </p>
 	  </div>
 	</div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 	  <div class="imagemaker_info_content">
 	    <p>
 	      I made this applet using the open-source character creator
-	      framework, <a href="https://github.com/ksadov/hackrew">hackrew</a>.
+	      framework, <a target="_blank" href="https://github.com/ksadov/hackrew">hackrew<span class="sr-only">(opens in a new window)</span></a>.
 	    </p>
 	  </div>
 	</div>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	<div id="info_wrap" class="imagemaker_info_wrapper">
 	  <div class="imagemaker_info_content">
 	    <p>
-	      I made this applet using the open-source character creator
+	      This builder is based on the open-source character creator
 	      framework, <a target="_blank" href="https://github.com/ksadov/hackrew">hackrew<span class="sr-only">(opens in a new window)</span></a>.
 	    </p>
 	  </div>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 </head>
 
 <body>
+	<script src="
+	https://chir.ag/projects/ntc/ntc.js"></script>
 	<script src="imagemaker.js"></script>
 	<header>
 		<h1>Character Builder</h1>
@@ -48,8 +50,8 @@
 								</div>
 							</div>
 							<div id="imagemaker_colorpalette" class="imagemaker_colorpalette">
-								<ul id="colorpalette_list">
-								</ul>
+								<div id="colorpalette_list">
+								</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Suggested changes

This branch provides alt text and aria labelling to elements in the interface that were lacking them. Whenever possible, the alt text is created programmatically based off the information provided in the image and folder structure in the `imagemaker.js` file.

- Items menu buttons obtain their accessible names from the folder their image assets come from
- Item selection buttons have alt text composed of the name of the item/setting in their file name, along with the name of the folder. the result is we get names like `Ears Big` or `Tail Long`. This felt stronger than just putting the `Big` or `Long` with no additional context.
- Color swatch options have an aria label applied that appends the folder name with the hex being used converted into its nearest CSS color keyword. the end result here is accessible names like `Ears White` or `Eyes Turquoise`. this is made possible by the [Name That Color Javascript Library](https://chir.ag/projects/ntc/)

## Screenshots

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/55950243-763b-488f-b8bd-06dac047a2d3">

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/8f2858c0-f994-40ab-a9fc-5b4670a31316">


<img width="1253" alt="image" src="https://github.com/user-attachments/assets/068ff248-3d86-4f89-b36d-f298f8e9e423">

